### PR TITLE
Bug fix multi-gpu with validation.

### DIFF
--- a/graphufs/training.py
+++ b/graphufs/training.py
@@ -338,9 +338,6 @@ def optimize(
     ), f"Number of validation steps ({n_steps_valid}) must be less than or equal to the number of training steps ({n_steps})"
     n_steps_valid_inc = (n_steps // n_steps_valid) * num_gpus
 
-    if emulator.mpi_rank == 0:
-        progress_bar = tqdm(total=n_steps, ncols=140, desc="Processing")
-
     # make a deep copy of slice 0
     sl = slice(0, num_gpus)
     i_batches = training_data["inputs"].isel(optim_step=sl).copy(deep=True)
@@ -354,6 +351,9 @@ def optimize(
     loss_avg = 0
     loss_valid_avg = 0
     mean_grad_avg = 0
+
+    if emulator.mpi_rank == 0:
+        progress_bar = tqdm(total=n_steps, ncols=140, desc="Processing")
 
     for k in range(0, n_steps, num_gpus):
         # When the number of batches is not evenly divisible by num_gpus


### PR DESCRIPTION
This PR closes #59
- Existing issue with calculation of `n_steps_valid_inc` that did not take into account `num_gpus`
- New issues introduced by recent shuffling of validation code

~~New issue uncovered that needs fixing~~
- ~~The second step in the first epoch is slow due to missed cache I suppose. This is why the first epoch is slower than the rest, but not that slow since N-1 steps are still fast. I need to figure out why and devise a workaround for it. However, this shouldn't matter since it only adds a few seconds to overall training. For a clean solution though, it would be best to finish all jitting before starting training.~~

The above issue is fixed now so that jitting happens completely before training. I think both should perform equally. Also, the workaround is quickly becoming ugly so we may want to diagnose the root cause of failed caches and fix it.

2-GPU run
```
$ python3 -W ignore train.py --num-gpus 2 --batch-size 16 --num-epochs 4 --chunks-per-epoch 1 --latent-size 32 --training-dates "1994-01-01T00" "1994-01-31T18" --validation-dates "1995-01-01T00" "1995-01-16T18"

[48 s] [Rank 0] [INFO] Started jitting optim_step
[85 s] [Rank 0] [INFO] Finished jitting optim_step
[85 s] [Rank 0] [INFO] Started jitting validation loss
[103 s] [Rank 0] [INFO] Finished jitting validation loss
loss = 2.83685, val_loss = 2.69186, mean(|grad|) = 0.02926014: 100%|██████████████████████████████████████████| 8/8 [00:12<00:00,  1.56s/it]
[116 s] [Rank 0] [INFO] Training on epoch 1 and chunk 0
loss = 2.47687, val_loss = 2.34244, mean(|grad|) = 0.02461840: 100%|██████████████████████████████████████████| 8/8 [00:01<00:00,  7.26it/s]
[118 s] [Rank 0] [INFO] Training on epoch 2 and chunk 0
loss = 2.19109, val_loss = 2.07483, mean(|grad|) = 0.01700734: 100%|██████████████████████████████████████████| 8/8 [00:01<00:00,  7.81it/s]
[120 s] [Rank 0] [INFO] Training on epoch 3 and chunk 0
loss = 2.00739, val_loss = 1.89970, mean(|grad|) = 0.01087313: 100%|██████████████████████████████████████████| 8/8 [00:01<00:00,  7.85it/s]

```
1 GPU run
```
$ python3 -W ignore train.py --num-gpus 1 --batch-size 16 --num-epochs 4 --chunks-per-epoch 1 --latent-size 32 --training-dates "1994-01-01T00" "1994-01-31T18" --validation-dates "1995-01-01T00" "1995-01-16T18"

[48 s] [Rank 0] [INFO] Started jitting optim_step
[73 s] [Rank 0] [INFO] Finished jitting optim_step
[73 s] [Rank 0] [INFO] Started jitting validation loss
[90 s] [Rank 0] [INFO] Finished jitting validation loss
loss = 2.65881, val_loss = 2.57178, mean(|grad|) = 0.02688663: 100%|██████████████████████████████████████████| 8/8 [00:01<00:00,  5.55it/s]
[92 s] [Rank 0] [INFO] Training on epoch 1 and chunk 0
loss = 2.11198, val_loss = 2.02962, mean(|grad|) = 0.01428000: 100%|██████████████████████████████████████████| 8/8 [00:01<00:00,  5.42it/s]
[94 s] [Rank 0] [INFO] Training on epoch 2 and chunk 0
loss = 1.84550, val_loss = 1.77257, mean(|grad|) = 0.00698029: 100%|██████████████████████████████████████████| 8/8 [00:01<00:00,  5.54it/s]
[96 s] [Rank 0] [INFO] Training on epoch 3 and chunk 0
loss = 1.69267, val_loss = 1.62373, mean(|grad|) = 0.00430727: 100%|██████████████████████████████████████████| 8/8 [00:01<00:00,  5.66it/s]

```
First epoch as fast as the others here. The speedup from 2 GPUs is 7.85/5.55 ~= 1.4X times. This will probably improve with the full network size but seems to be less than what it used to be before the optimization.

2-GPU run after first epoch issue fix
```
[48 s] [Rank 0] [INFO] Starting Training
[48 s] [Rank 0] [INFO] Training on epoch 0 and chunk 0
[49 s] [Rank 0] [INFO] Started jitting optim_step
[113 s] [Rank 0] [INFO] Finished jitting optim_step
loss = 2.83681, val_loss = 2.69185, mean(|grad|) = 0.02926183: 100%|██████████████████████████████████████████| 8/8 [00:01<00:00,  6.95it/s]
[115 s] [Rank 0] [INFO] Training on epoch 1 and chunk 0
loss = 2.47689, val_loss = 2.34235, mean(|grad|) = 0.02461797: 100%|██████████████████████████████████████████| 8/8 [00:01<00:00,  7.09it/s]
[116 s] [Rank 0] [INFO] Training on epoch 2 and chunk 0
loss = 2.19109, val_loss = 2.07472, mean(|grad|) = 0.01700616: 100%|██████████████████████████████████████████| 8/8 [00:01<00:00,  7.74it/s]
[118 s] [Rank 0] [INFO] Training on epoch 3 and chunk 0
loss = 2.00741, val_loss = 1.89969, mean(|grad|) = 0.01087252: 100%|██████████████████████████████████████████| 8/8 [00:01<00:00,  7.70it/s]

```