### PR TITLE
Specify number of dask threads

### DIFF
--- a/graphufs/emulator.py
+++ b/graphufs/emulator.py
@@ -79,6 +79,7 @@ class ReplayEmulator:
     log_only_rank0 = None           # log only messages from rank 0
     use_jax_distributed = None      # Use jax's distributed mechanism, no need for manula mpi4jax calls
     use_xla_flags = None            # Use recommended flags for XLA and NCCL https://jax.readthedocs.io/en/latest/gpu_performance_tips.html
+    dask_threads = None             # number of threads to use for dask
 
     # model config options
     resolution = None               # nominal spatial resolution

--- a/prototypes/p1/p1.py
+++ b/prototypes/p1/p1.py
@@ -97,6 +97,7 @@ class P1Emulator(ReplayEmulator):
     log_only_rank0 = False
     use_jax_distributed = False
     use_xla_flags = False
+    dask_threads = 4
 
     # model config options
     resolution = 1.0

--- a/prototypes/p1/train.py
+++ b/prototypes/p1/train.py
@@ -1,6 +1,7 @@
 import os
 import logging
 import time
+import dask
 
 import optax
 from graphufs import (
@@ -53,9 +54,11 @@ if __name__ == "__main__":
     # for multi-gpu training
     init_devices(p1)
 
-    logging.info("Loading first chunk of training and validation")
+    # configuring dask
+    dask.config.set(scheduler="threads", num_workers=p1.dask_threads)
 
     # data generators
+    logging.info("Loading first chunk of training and validation")
     trainer = DataGenerator(
         emulator=p1,
         n_optim_steps=p1.steps_per_chunk,


### PR DESCRIPTION
Adds option to specify the number of dask threads (default=4). This is the setup that I used to get the best result.
@timothyas Lets merge this and experiment with the I/O improvement you found with the slurm defaults on Azure.