### PR TITLE
Add testing script to P1.

### DIFF
--- a/evaluate-graphufs.sh
+++ b/evaluate-graphufs.sh
@@ -2,7 +2,7 @@
 
 export PYTHONPATH=$PYTHONPATH:$PWD/weatherbench2:$PWD/weatherbench2/weatherbench2:$PWD/weatherbench2/scripts
 
-GRAPHUFS_ZARR_DIR="$PWD/prototypes/p0/zarr-stores"
+GRAPHUFS_ZARR_DIR="$PWD/prototypes/p1/zarr-stores"
 
 OBS_PATH="gs://weatherbench2/datasets/era5/1959-2022-6h-64x32_equiangular_conservative.zarr"
 
@@ -15,8 +15,8 @@ python weatherbench2/scripts/evaluate.py \
   --output_file_prefix=graphufs_ \
   --input_chunks=init_time=1 \
   --eval_configs=deterministic \
-  --time_start=1995-01-01 \
-  --time_stop=1995-12-31 \
-  --variables="surface_pressure,temperature,10m_u_component_of_wind,10m_v_component_of_wind" \
-  --levels=100,500,1000
+  --time_start=1994-01-01 \
+  --time_stop=1994-01-16 \
+  --variables="surface_pressure,10m_u_component_of_wind,10m_v_component_of_wind,2m_temperature,temperature,u_component_of_wind,v_component_of_wind,vertical_velocity,specific_humidity,geopotential" \
+  --levels=50,100,150,200,250,300,400,500,600,700,850,925,1000
 

--- a/graphufs/emulator.py
+++ b/graphufs/emulator.py
@@ -591,7 +591,8 @@ class ReplayEmulator:
                 base_name = f"{self.local_store_path}/extracted/{mode}-chunk-{chunk_id:04d}-of-{n_chunks:04d}-rank-{self.mpi_rank:03d}-of-{self.mpi_size:03d}-bs-{self.batch_size}-"
                 def combine_chunk_save(xds, name):
                     xds = xr.combine_by_coords(xds)
-                    xds = self.rechunk(xds)
+                    if name != "inittimes":
+                        xds = self.rechunk(xds)
                     if self.use_preprocessed:
                         file_name = f"{base_name}{name}.zarr"
                         xds.to_zarr(file_name)

--- a/graphufs/evaluation.py
+++ b/graphufs/evaluation.py
@@ -37,14 +37,21 @@ def convert_wb2_format(gufs, ds, inittimes) -> xr.Dataset:
     ds_out = regridder(ds)
 
     # rename variables
-    ds_out = ds_out.rename_vars(
-        {
-            "pressfc": "surface_pressure",
-            "tmp": "temperature",
-            "ugrd10m": "10m_u_component_of_wind",
-            "vgrd10m": "10m_v_component_of_wind",
-        }
-    )
+    rename_dict = {
+        "pressfc": "surface_pressure",
+        "ugrd10m": "10m_u_component_of_wind",
+        "vgrd10m": "10m_v_component_of_wind",
+        "tmp2m": "2m_temperature",
+        "tmp": "temperature",
+        "ugrd": "u_component_of_wind",
+        "vgrd": "v_component_of_wind",
+        "dzdt": "vertical_velocity",
+        "spfh": "specific_humidity",
+        "delz": "geopotential",
+        "prateb_ave": "total_preciptation_3hr",
+    }
+    rename_dict = {k: rename_dict[k] for k in ds_out.data_vars.keys()}
+    ds_out = ds_out.rename_vars(rename_dict)
 
     # fix pressure levels to match obs
     ds_out["level"] = np.array(list(gufs.pressure_levels), dtype=np.float32)

--- a/prototypes/p0/simple_emulator.py
+++ b/prototypes/p0/simple_emulator.py
@@ -101,12 +101,14 @@ class P0Emulator(ReplayEmulator):
     num_workers = 1
     load_chunk = True
     store_loss = True
+    use_preprocessed = True
 
     # others
     num_gpus = 1
     log_only_rank0 = False
     use_jax_distributed = False
     use_xla_flags = False
+    dask_threads = None
 
 tree_util.register_pytree_node(
     P0Emulator,

--- a/prototypes/p0/train.py
+++ b/prototypes/p0/train.py
@@ -137,9 +137,7 @@ if __name__ == "__main__":
                 params=params,
                 state=state,
                 emulator=gufs,
-                input_batches=data["inputs"],
-                target_batches=data["targets"],
-                forcing_batches=data["forcings"],
+                testing_data=data,
             )
 
             targets = data["targets"]

--- a/prototypes/p1/test.py
+++ b/prototypes/p1/test.py
@@ -1,0 +1,96 @@
+import os
+import logging
+import time
+import dask
+import shutil
+
+from graphufs import (
+    predict,
+    DataGenerator,
+    init_devices,
+    convert_wb2_format,
+    compute_rmse_bias,
+)
+
+from p1 import P1Emulator
+from ufs2arco import Timer
+
+if __name__ == "__main__":
+
+    timer1 = Timer()
+
+    # parse arguments
+    p1, args = P1Emulator.from_parser()
+
+    # for multi-gpu training
+    init_devices(p1)
+
+    # configuring dask
+    if p1.dask_threads is not None:
+        dask.config.set(scheduler="threads", num_workers=p1.dask_threads)
+
+    # data generators
+    testor = DataGenerator(
+        emulator=p1,
+        n_optim_steps=p1.steps_per_chunk,
+        max_queue_size=p1.max_queue_size,
+        num_workers=p1.num_workers,
+        mode="testing",
+    )
+
+    # load weights
+    logging.info(f"Loading weights: {args.id}")
+    params, state = p1.load_checkpoint(args.id)
+
+    logging.info("Starting Testing")
+
+    # create predictions and targets zarr file for WB2
+    predictions_zarr_name = f"{p1.local_store_path}/graphufs_predictions.zarr"
+    targets_zarr_name = f"{p1.local_store_path}/graphufs_targets.zarr"
+    if os.path.exists(predictions_zarr_name):
+        shutil.rmtree(predictions_zarr_name)
+    if os.path.exists(targets_zarr_name):
+        shutil.rmtree(targets_zarr_name)
+
+    stats = {}
+    for c in range(p1.chunks_per_epoch):
+        logging.info(f"Testing on chunk {c+1}")
+        start1 = time.time()
+
+        # get chunk of data in parallel with inference
+        data = testor.get_data()
+
+        # run predictions
+        predictions = predict(
+            params=params,
+            state=state,
+            emulator=p1,
+            testing_data=data,
+        )
+
+        targets = data["targets"]
+        inittimes = data["inittimes"]
+
+        # Compute rmse and bias comparing targets and predictions
+        compute_rmse_bias(predictions, targets, stats, c)
+
+        # write predictions chunk by chunk to avoid storing all of it in memory
+        predictions = convert_wb2_format(p1, predictions, inittimes)
+        predictions = predictions.dropna("time")
+        predictions.to_zarr(predictions_zarr_name, append_dim="time" if c else None)
+
+        # write also targets to compute metrics against it with wb2
+        targets = convert_wb2_format(p1, targets, inittimes)
+        targets = targets.dropna("time")
+        targets.to_zarr(targets_zarr_name, append_dim="time" if c else None)
+
+        end1 = time.time()
+        logging.info(f"Done with chunk {c+1} in: {end1 - start1:.4f} sec")
+
+    logging.info("--------- Statistiscs ---------")
+    for k, v in stats.items():
+        logging.info(f"{k:32s}: RMSE: {v[0]} BIAS: {v[1]}")
+
+    # stop the data generators
+    testor.stop()
+    logging.info("Done Testing")


### PR DESCRIPTION
This PR adds testing to P1. Tested only locally on barely trained models.

To run testing on model 8 
```
$ python3 -W ignore test.py --id 8 --load-chunk no --use-preprocessed no --chunks-per-epoch 1 --num-gpus 1 --batch-size 4 --testing-dates "1994-01-01T00" "1994-01-08T18" --local-store-path "./zarr-stores"

[1 s] [Rank 0] [INFO] Unable to initialize backend 'rocm': NOT_FOUND: Could not find registered platform with name: "rocm". Available platform names are: CUDA
[1 s] [Rank 0] [INFO] Unable to initialize backend 'tpu': INTERNAL: Failed to open libtpu.so: libtpu.so: cannot open shared object file: No such file or directory
[1 s] [Rank 0] [INFO] Using 1 GPUs.
[1 s] [Rank 0] [INFO] 
jax:    0.4.26
jaxlib: 0.4.23.dev20240407
numpy:  1.26.4
python: 3.11.9 | packaged by conda-forge | (main, Apr 19 2024, 18:36:13) [GCC 12.3.0]
jax.devices (1 total, 1 local): [cuda(id=0)]
process_count: 1
platform: uname_result(system='Linux', node='danidesti-desktop', release='6.2.0-37-generic', version='#38~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Thu Nov  2 18:01:13 UTC 2', machine='x86_64')


$ nvidia-smi
Tue Jun 18 15:42:19 2024       
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 550.54.15              Driver Version: 550.54.15      CUDA Version: 12.4     |
|-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  NVIDIA GeForce RTX 2070 ...    Off |   00000000:07:00.0  On |                  N/A |
| 41%   36C    P2             32W /  215W |     316MiB /   8192MiB |      8%      Default |
|                                         |                        |                  N/A |
+-----------------------------------------+------------------------+----------------------+
                                                                                         
+-----------------------------------------------------------------------------------------+
| Processes:                                                                              |
|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
|        ID   ID                                                               Usage      |
|=========================================================================================|
|    0   N/A  N/A      5249      G   /usr/lib/xorg/Xorg                            143MiB |
|    0   N/A  N/A      5405      G   /usr/bin/gnome-shell                           37MiB |
|    0   N/A  N/A    221247      G   ...seed-version=20240614-130101.053000         28MiB |
|    0   N/A  N/A    940315      C   python3                                       102MiB |
+-----------------------------------------------------------------------------------------+

[1 s] [Rank 0] [INFO] Local devices: 1 [cuda(id=0)]
[1 s] [Rank 0] [INFO] Global devices: 1 [cuda(id=0)]
[1 s] [Rank 0] [INFO] Loading weights: 8
[1 s] [Rank 0] [INFO] Chunks for testing: 1 each with 63 time stamps
[5 s] [Rank 0] [INFO] Starting Testing
[5 s] [Rank 0] [INFO] Testing on chunk 1
Processing: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████| 15/15 [01:51<00:00,  7.41s/it]
[139 s] [Rank 0] [INFO] Done with chunk 1 in: 133.3182 sec
[139 s] [Rank 0] [INFO] --------- Statistiscs ---------
[139 s] [Rank 0] [INFO] delz                            : RMSE: 1.1543720960617065 BIAS: -0.012919837608933449
[139 s] [Rank 0] [INFO] dzdt                            : RMSE: 0.030421243980526924 BIAS: -0.0004581176326610148
[139 s] [Rank 0] [INFO] prateb_ave                      : RMSE: 7.759756408631802e-05 BIAS: 2.132839199475711e-06
[139 s] [Rank 0] [INFO] pressfc                         : RMSE: 90.9905776977539 BIAS: -2.153347969055176
[139 s] [Rank 0] [INFO] spfh                            : RMSE: 0.0003636755864135921 BIAS: 4.3088471102237236e-06
[139 s] [Rank 0] [INFO] tmp                             : RMSE: 0.7807185053825378 BIAS: 0.004859591368585825
[139 s] [Rank 0] [INFO] tmp2m                           : RMSE: 0.7537156343460083 BIAS: -0.04681195318698883
[139 s] [Rank 0] [INFO] ugrd                            : RMSE: 2.365126371383667 BIAS: -0.059976331889629364
[139 s] [Rank 0] [INFO] ugrd10m                         : RMSE: 1.255868911743164 BIAS: -0.03533758223056793
[139 s] [Rank 0] [INFO] vgrd                            : RMSE: 2.5643837451934814 BIAS: -0.017677556723356247
[139 s] [Rank 0] [INFO] vgrd10m                         : RMSE: 1.249696135520935 BIAS: -0.03961336612701416
[139 s] [Rank 0] [INFO] Done Testing
[WARNING] yaksa: 10 leaked handle pool objects
```
Since running testing in chunks messes up the boundaries make sure to use 1 chunk, not load it into RAM, and not use preprocessed data by specifying `-load-chunk no --use-preprocessed no --chunks-per-epoch 1`. This will be slow but we don't care about it in testing.

The weatherbench2 evaluation can then be run after modifying the start and stop times. Precipitation is left out of the evaluation until we get it working.
```
$ ./evaluate_graphufs.sh

I0618 15:45:03.087143 140619553220416 evaluation.py:400] Logging metric: mse
I0618 15:45:03.246891 140619553220416 evaluation.py:425] Logging metric done: mse
I0618 15:45:03.246967 140619553220416 evaluation.py:400] Logging metric: acc
I0618 15:48:52.919699 140619553220416 evaluation.py:425] Logging metric done: acc
I0618 15:48:52.919776 140619553220416 evaluation.py:400] Logging metric: bias
I0618 15:48:53.101954 140619553220416 evaluation.py:425] Logging metric done: bias
I0618 15:48:53.102033 140619553220416 evaluation.py:400] Logging metric: mae
I0618 15:48:53.201093 140619553220416 evaluation.py:425] Logging metric done: mae
I0618 15:50:03.609626 140619553220416 evaluation.py:467] Logging Evaluation complete:
<xarray.Dataset> Size: 3kB
Dimensions:                  (lead_time: 1, level: 13, metric: 4)
Coordinates:
  * lead_time                (lead_time) timedelta64[ns] 8B 03:00:00
  * level                    (level) float32 52B 50.0 100.0 ... 925.0 1e+03
  * metric                   (metric) object 32B 'acc' 'bias' 'mae' 'mse'
Data variables:
    surface_pressure         (metric, lead_time) float64 32B dask.array<chunksize=(4, 1), meta=np.ndarray>
    10m_u_component_of_wind  (metric, lead_time) float64 32B dask.array<chunksize=(4, 1), meta=np.ndarray>
    10m_v_component_of_wind  (metric, lead_time) float64 32B dask.array<chunksize=(4, 1), meta=np.ndarray>
    2m_temperature           (metric, lead_time) float64 32B dask.array<chunksize=(4, 1), meta=np.ndarray>
    temperature              (metric, lead_time, level) float64 416B dask.array<chunksize=(4, 1, 7), meta=np.ndarray>
    u_component_of_wind      (metric, lead_time, level) float64 416B dask.array<chunksize=(4, 1, 7), meta=np.ndarray>
    v_component_of_wind      (metric, lead_time, level) float64 416B dask.array<chunksize=(4, 1, 7), meta=np.ndarray>
    vertical_velocity        (metric, lead_time, level) float64 416B dask.array<chunksize=(4, 1, 7), meta=np.ndarray>
    specific_humidity        (metric, lead_time, level) float64 416B dask.array<chunksize=(4, 1, 7), meta=np.ndarray>
    geopotential             (metric, lead_time, level) float64 416B dask.array<chunksize=(4, 1, 7), meta=np.ndarray>
    wind_vector              (metric, lead_time, level) float64 416B dask.array<chunksize=(4, 1, 7), meta=np.ndarray>
    10m_wind_vector          (metric, lead_time) float64 32B dask.array<chunksize=(4, 1), meta=np.ndarray>
I0618 15:50:21.690220 140619553220416 evaluation.py:471] Logging Saved results to ./graphufs_deterministic.nc
```
Looking at the netcdf file

<details>
<summary>$ncdump ./graphufs_deterministic.nc</summary>

netcdf graphufs_deterministic {
dimensions:
	lead_time = 1 ;
	level = 13 ;
	metric = 4 ;
	string4 = 4 ;
variables:
	float level(level) ;
		level:_FillValue = NaNf ;
	char metric(metric, string4) ;
		metric:_Encoding = "utf-8" ;
	double temperature(metric, lead_time, level) ;
		temperature:_FillValue = NaN ;
	double u_component_of_wind(metric, lead_time, level) ;
		u_component_of_wind:_FillValue = NaN ;
	double v_component_of_wind(metric, lead_time, level) ;
		v_component_of_wind:_FillValue = NaN ;
	double vertical_velocity(metric, lead_time, level) ;
		vertical_velocity:_FillValue = NaN ;
	double specific_humidity(metric, lead_time, level) ;
		specific_humidity:_FillValue = NaN ;
	double geopotential(metric, lead_time, level) ;
		geopotential:_FillValue = NaN ;
	double wind_vector(metric, lead_time, level) ;
		wind_vector:_FillValue = NaN ;
	double surface_pressure(metric, lead_time) ;
		surface_pressure:_FillValue = NaN ;
	double \10m_u_component_of_wind(metric, lead_time) ;
		\10m_u_component_of_wind:_FillValue = NaN ;
	double \10m_v_component_of_wind(metric, lead_time) ;
		\10m_v_component_of_wind:_FillValue = NaN ;
	double \2m_temperature(metric, lead_time) ;
		\2m_temperature:_FillValue = NaN ;
	double \10m_wind_vector(metric, lead_time) ;
		\10m_wind_vector:_FillValue = NaN ;
	int lead_time(lead_time) ;
		lead_time:units = "hours" ;
data:

 level = 50, 100, 150, 200, 250, 300, 400, 500, 600, 700, 850, 925, 1000 ;

 metric =
  "acc",
  "bias",
  "mae",
  "mse" ;

 temperature =
  0.920253947211004, 0.951038630988701, 0.90665392595004, 0.884309306084481, 
    0.838254647667601, 0.860508298227519, 0.755816694812536, 
    0.716077992208852, 0.700266366082755, 0.686770335508518, 
    0.671413230107602, 0.587490024783715, 0.476495133214234,
  0.621257577698056, -0.174668398001981, -0.578451280873732, 
    -0.457947567140596, -0.812493965263921, -0.401010319133329, 
    0.219608333355052, -0.0671277793680981, -0.228047308706342, 
    -0.732401970115976, -0.883862725249708, -0.806651298734447, 
    -1.00344006485171,
  1.02151219333576, 0.724278904490584, 1.08504988317344, 1.152554983782, 
    1.3733485758205, 0.897635315400925, 1.55191283522598, 1.68064939792769, 
    1.69696195742593, 1.66796901544513, 1.74050073080858, 1.89500006172573, 
    2.72475492055044,
  1.89543331593636, 0.891269250466996, 1.78339621095778, 2.33880339479052, 
    2.88178993169591, 1.87833577694473, 5.43105127604685, 7.82832195710978, 
    8.73341299079284, 9.52514761984748, 11.211826866932, 13.0846286938516, 
    23.2606878574738 ;

 u_component_of_wind =
  0.916085223895527, 0.94979100840513, 0.960163461583123, 0.950913509211098, 
    0.939469074904239, 0.934008286080943, 0.930369547583013, 
    0.925869474704394, 0.912901410849315, 0.903666629238818, 
    0.864629337597954, 0.847264740557315, 0.842515511994467,
  -0.6784081009506, -0.45423501346612, -0.319737403246674, 
    -0.0589311467073445, 0.097267944709245, -0.00357025848483459, 
    -0.219947400452938, -0.0862775698243911, 0.0419367766113387, 
    0.125214148829451, 0.0854361465455829, 0.044193071162408, 
    -0.0458459339520556,
  2.07025195810265, 1.90578184798951, 2.04704913981833, 2.44203576519731, 
    2.77647879293045, 2.7582924609587, 2.34936265469194, 2.0128010376665, 
    1.78625467146114, 1.67410955909808, 1.78609692451327, 1.85150140159971, 
    1.39646484721849,
  6.960527699054, 5.97960969593135, 7.36144657662068, 11.8044361297026, 
    15.8377960747024, 16.2166466035452, 11.7842463361127, 8.59874965502798, 
    7.41894936747339, 6.40525527201322, 7.02664938396897, 7.34806300101936, 
    4.02825575984122 ;

 v_component_of_wind =
  0.863863510566357, 0.925282076332155, 0.934024070657325, 0.918612000185338, 
    0.892919080871257, 0.8759471309263, 0.862469091338049, 0.862684956578773, 
    0.861510544512505, 0.851743874689534, 0.796758868448042, 
    0.770627098853884, 0.782826228248289,
  -0.00369964299226128, -0.00741673164821725, -0.0376253407338348, 
    0.0247219975264401, 0.0430425548419175, -0.0697008327665824, 
    -0.119457174908972, -0.0416799377941578, -0.0191599223971726, 
    -0.0736653605988305, -0.127397508300422, -0.0901425335331362, 
    0.0060413901481065,
  2.10094534641137, 2.09487925159674, 2.54638090736114, 3.21211062400827, 
    3.76374500663595, 3.74529192278943, 3.18239700705434, 2.6042126538021, 
    2.20051224929501, 2.00632573377911, 2.04820451929063, 2.17209097789782, 
    1.57042679967382,
  7.30261636113637, 7.43285640047326, 12.1561898098699, 22.4613163965873, 
    32.9207235275398, 34.7577542522666, 25.4850823444619, 16.4255181254921, 
    11.339219705271, 9.21875071967332, 9.86604227130039, 11.3662074026991, 
    6.03142214688527 ;

 vertical_velocity =
  -0.202399342227737, -0.336240508168182, -0.3327445141289, 
    -0.31673202819083, -0.299580090836314, -0.269286007997925, 
    -0.21184327231852, -0.167030574419801, -0.125273583014859, 
    -0.0944355517052164, -0.0372307236840805, -0.0340829538050748, 
    -0.0614289097072846,
  -0.00106874798665292, -0.000898691292191479, -0.00093281311999229, 
    -0.00134553469479472, -0.00143690373597593, -0.000711041851283523, 
    -0.000779570711982505, -0.00110632971399831, -0.00141523338801499, 
    -0.00227472024514178, -0.00558300364340234, -0.0091226864162112, 
    -0.0122811249073647,
  0.00690698476109099, 0.0123998880858987, 0.0222078914696834, 
    0.0361606300957908, 0.0536827278298785, 0.0676060889512484, 
    0.0807575855618429, 0.0827311084981849, 0.0804768716852743, 
    0.0773479573168364, 0.0634996087797407, 0.0486928353553946, 
    0.0293969747113905,
  0.00011694180707292, 0.000296271480072814, 0.00101709095461755, 
    0.00282267171919435, 0.00607522774464826, 0.00954152026516651, 
    0.0140210753719067, 0.015204699884404, 0.0143248326381026, 
    0.0127244191481889, 0.00839188493165766, 0.00537370638569317, 
    0.00359713721076524 ;

 specific_humidity =
  -0.308209193234512, 0.861904568333447, 0.687325357367144, 
    0.788517560621509, 0.820984184041998, 0.871559212171651, 
    0.879401830187401, 0.87821507896858, 0.860272583150654, 
    0.854347694892176, 0.756977893396944, 0.749703085469084, 0.871166284076653,
  -2.28574968205333e-07, -6.32907138219362e-08, -7.54810514992425e-07, 
    -2.66408631882167e-06, -7.60508479643837e-06, -4.03837062527492e-07, 
    3.52118376678455e-05, 3.59577175012509e-05, 3.29667295403163e-05, 
    -4.93660582342768e-05, 8.69044792889017e-05, 0.000111760096703763, 
    8.22651942667475e-05,
  2.37940231373133e-07, 1.46366066407441e-07, 8.69271046844111e-07, 
    4.28775388689088e-06, 1.44679635310803e-05, 3.05984576410249e-05, 
    0.000102994341774145, 0.000199048664855619, 0.000320334416924627, 
    0.000425247724761443, 0.000641687065933745, 0.00055957112538223, 
    0.000432748992400347,
  7.13257691793805e-14, 3.54856953515707e-14, 1.79193571265457e-12, 
    4.58138155894508e-11, 5.17197436864964e-10, 2.30881056469082e-09, 
    2.50416090820002e-08, 9.51665247925483e-08, 2.47262222981567e-07, 
    4.39019156264125e-07, 9.46085556380952e-07, 6.89703583175252e-07, 
    4.10950642977266e-07 ;

 geopotential =
  0.127446856687712, 0.180930010081665, 0.165566773909391, 0.122258538231469, 
    0.0936144791332657, 0.0783395517721602, 0.0658667335247909, 
    0.0612440980046406, 0.0558318397040029, 0.0442541282740366, 
    0.0345783171900131, 0.0376578881422524, 0.0955733852520467,
  -200973.998346777, -159754.901284266, -135519.483675973, -117745.476597936, 
    -103524.683670132, -91528.3424221492, -71707.8700457854, 
    -55508.7110769837, -41754.0942542959, -29782.4524107178, 
    -14268.1918186309, -7383.08872065949, -958.377106347889,
  200973.998346777, 159754.901284266, 135519.483675973, 117745.476597936, 
    103524.683670132, 91528.3424221492, 71707.8700457854, 55508.7110769837, 
    41754.0942542959, 29782.4524107178, 14268.1918186309, 7383.08872065949, 
    1134.37168735757,
  40396889364.367, 25534571636.3913, 18386200604.4237, 13887157098.6616, 
    10739006878.0188, 8395778255.2387, 5153932061.39921, 3088713393.06017, 
    1748046742.59212, 889778725.718109, 204762530.144685, 55312036.0608372, 
    1577866.13174557 ;

 wind_vector =
  _, _, _, _, _, _, _, _, _, _, _, _, _,
  _, _, _, _, _, _, _, _, _, _, _, _, _,
  _, _, _, _, _, _, _, _, _, _, _, _, _,
  14.2631440597367, 13.4124660941943, 19.5176363857538, 34.265752524956, 
    48.7585196147748, 50.9744008298898, 37.2693286630326, 25.0242677821383, 
    18.7581690727646, 15.6240059925883, 16.8926916536345, 18.7142704047572, 
    10.0596779133508 ;

 surface_pressure =
  0.91956849157052,
  0.867468828774581,
  191.70041146118,
  72686.1400090262 ;

 \10m_u_component_of_wind =
  0.866832038783302,
  -0.0812565778035589,
  1.15423688003312,
  2.93615350422217 ;

 \10m_v_component_of_wind =
  0.800603011001032,
  -0.0448252198564354,
  1.37118744383292,
  4.67607292865326 ;

 \2m_temperature =
  0.639952014662172,
  0.148185237787,
  1.68072210508073,
  8.8455812516877 ;

 \10m_wind_vector =
  _,
  _,
  _,
  7.61222643330521 ;

 lead_time = 3 ;
}


</details>