### PR TITLE
Add batch splitting.

### DIFF
--- a/graphufs/emulator.py
+++ b/graphufs/emulator.py
@@ -65,6 +65,7 @@ class ReplayEmulator:
 
     # training protocol
     batch_size = None               # number of forecasts averaged over in loss per optim_step
+    num_batch_splits = None         # number of batch splits
     num_epochs = None               # number of epochs
     chunks_per_epoch = None         # number of chunks per epoch
     steps_per_chunk = None          # number of steps to train for in each chunk

--- a/prototypes/p1/p1.py
+++ b/prototypes/p1/p1.py
@@ -83,6 +83,7 @@ class P1Emulator(ReplayEmulator):
 
     # training protocol
     batch_size = 32
+    num_batch_splits = 1
     num_epochs = 2
     chunks_per_epoch = 48
     steps_per_chunk = None


### PR DESCRIPTION
This PR closes #76 
We should be able to train with larger batch size than the device allows. Since the mini-batches are processed sequentially, theoretically it should be possible to train with arbitrarily large batch size, but that is definately not the case. I was able to go upto 4X larger batch size on my local machine, and just 2X larger on the Azure GPUs. We needs to understand better what is consuming the most GPU memory.

- New option `--num-batch-splits`  added to specify the number of splits. When you increase the batch size by 4X times, set this variable to 4.
- The way it works is that loss, gradients and diagnostics are computed for each of the mini-batches independently in a loop, and then the result is aggregated. This is similar to a multi-gpu implementation but for sequential processing using 1 GPU.

TODO:
- Figure out what is limiting it from using any batch size. The model size (unlikely), the input data size or intermediate computation result (most likely)? Though we have about 83 input channels, the latent size in P1 is 512 so the intermediate outputs probably require 512/83=6 times more memory than the input.