### PR TITLE
Fix loss_by_channel variable in training

### DIFF
--- a/graphufs/stacked_training.py
+++ b/graphufs/stacked_training.py
@@ -378,7 +378,7 @@ def optimize(
 
     n_channels = target_batch.shape[-1]
     loss_by_channel = np.vstack(loss_by_channel)
-    loss_by_channel_valid = np.vstack(loss_by_channel_valid)
+    loss_by_channel_valid = np.vstack(loss_by_channel_valid).mean(axis=0, keepdims=True)
 
     loss_ds["optim_step"] = [x + previous_optim_steps for x in optim_steps]
     loss_ds["epoch"] = [1 + previous_epochs]


### PR DESCRIPTION
As it turns out, the `loss_by_channel` bug came in #82, since here it was changed to loop over each of the samples in the loss function, rather than handle the batch all at once.

This PR fixes the `loss_by_channel` variable, and adds it for the validation loss. Now we can look at the loss as a function of the channel (and map that back to the variable/vertical level etc.).

I tested this out, and confirmed we can make crazy plots like this again

For training
![Screenshot 2024-10-30 at 4 55 17 PM](https://github.com/user-attachments/assets/8dba9827-4b39-4a6c-ac0c-0d08f2454271)

And for validation
![Screenshot 2024-10-30 at 4 55 31 PM](https://github.com/user-attachments/assets/f96845db-d655-470d-8301-b01f9bd72df0)
